### PR TITLE
Fix tsconfig include path

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "pages/api/reading.tss"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "pages/api/readings.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- correct the path in `tsconfig.json` that references the readings API file

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'formidable', etc.)*